### PR TITLE
Minor syntax fix to play nice with newer versions of Python

### DIFF
--- a/autohidewibox.py
+++ b/autohidewibox.py
@@ -147,7 +147,7 @@ try:
                 field = None
                 key_state = None
 
-        if (field is "event") and detail_match:
+        if (field == "event") and detail_match:
             _debug(detail_match)
             try:
                 if detail_match.group(1) in super_keys:


### PR DESCRIPTION
Namely, Python 3.8.2 would complain in the following way:

    autohidewibox.py:150: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if (field is "event") and detail_match:
